### PR TITLE
Applies fix ci in advance.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ setup:
 	go get -v -u github.com/alecthomas/gometalinter
 	go get -v -u github.com/jstemmer/go-junit-report
 	go get -v github.com/mattn/goveralls
+	go get -v github.com/dnephin/govet
 	gometalinter --install --update
 	glide install --strip-vendor
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ setup:
 	go get -v -u github.com/alecthomas/gometalinter
 	go get -v -u github.com/jstemmer/go-junit-report
 	go get -v github.com/mattn/goveralls
-	go get -v github.com/dnephin/govet
 	gometalinter --install --update
 	glide install --strip-vendor
 
@@ -68,7 +67,7 @@ check:
 	go install ./cmd
 
 	gometalinter --concurrency=$(METALINTER_CONCURRENCY) --deadline=$(METALINTER_DEADLINE)s ./... --vendor --linter='errcheck:errcheck:-ignore=net:Close' --cyclo-over=20 \
-		--linter='vet:govet --no-recurse -composites=false:PATH:LINE:MESSAGE' --disable=interfacer --dupl-threshold=50
+		--linter='vet:go vet --no-recurse -composites=false:PATH:LINE:MESSAGE' --disable=interfacer --dupl-threshold=50
 
 check-all:
 	go install ./cmd

--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ Usage of ./build/bin/darwin/kube2iam:
       --base-role-arn string                Base role ARN
       --debug                               Enable debug features
       --default-role string                 Fallback role to use when annotation is not set
+      --extra-security                      Hide additional metadata URLs
       --hide-user-data                      Hide the instance's user-data
       --host-interface string               Host interface for proxying AWS metadata (default "docker0")
       --host-ip string                      IP address of host

--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ Usage of ./build/bin/darwin/kube2iam:
       --base-role-arn string                Base role ARN
       --debug                               Enable debug features
       --default-role string                 Fallback role to use when annotation is not set
+      --hide-user-data                      Hide the instance's user-data
       --host-interface string               Host interface for proxying AWS metadata (default "docker0")
       --host-ip string                      IP address of host
       --iam-role-key string                 Pod annotation key used to retrieve the IAM role (default "iam.amazonaws.com/role")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.BoolVar(&s.Verbose, "verbose", false, "Verbose")
 	fs.BoolVar(&s.Version, "version", false, "Print the version and exits")
 	fs.BoolVar(&s.HideUserData, "hide-user-data", false, "Hide the instance's user-data")
+	fs.BoolVar(&s.ExtraSecurity, "extra-security", false, "Hide additional metadata URLs")
 }
 
 func main() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.StringVar(&s.LogLevel, "log-level", s.LogLevel, "Log level")
 	fs.BoolVar(&s.Verbose, "verbose", false, "Verbose")
 	fs.BoolVar(&s.Version, "version", false, "Print the version and exits")
+	fs.BoolVar(&s.HideUserData, "hide-user-data", false, "Hide the instance's user-data")
 }
 
 func main() {


### PR DESCRIPTION
This pull request turns travis' test into green with the following pull request open on kube2iam.

- [New flags --hide-user-data & --extra-security #137](https://github.com/jtblin/kube2iam/pull/137)

This fix incorporates the following pull requests ahead of time.

- https://github.com/jtblin/kube2iam/pull/158


`--hide-user-data` is a very nice update, we need it, so I hope it will be included in the owner.